### PR TITLE
Fixes #2 - Update nicstat.c

### DIFF
--- a/nicstat.c
+++ b/nicstat.c
@@ -1814,8 +1814,17 @@ update_timestr(time_t *tptr)
 	(void) strftime(g_timestr, sizeof (g_timestr), "%H:%M:%S", tm);
 }
 
-#define	TCPSTAT(field)	(g_tcp_new->field - g_tcp_old->field)
-#define	UDPSTAT(field)	(g_udp_new->field - g_udp_old->field)
+static uint32_t
+tcpudpstat(uint32_t new, uint32_t old)
+{
+	if (new < old)
+		return((UINT32_MAX - old) + new);
+	else
+		return(new - old);
+}
+
+#define	TCPSTAT(field)	tcpudpstat(((g_tcp_new)->field), ((g_tcp_old)->field))
+#define	UDPSTAT(field)	tcpudpstat(((g_udp_new)->field), ((g_udp_old)->field))
 
 static void
 print_tcp()


### PR DESCRIPTION
Allows for one kstat (uint32_t) wrap during a sample interval - prevents wildly inaccurate data rate stats following that wrap.
Unit tests across wrap of consumed kstat data:

Test:
========
% ./build/amd64/nicstat -t 20 &
% while true ; do
        kstat tcp | grep outDataByte
        sleep 5
        done &

% scp /var/tmp/fug.tar gesheph@tcx32-09.us.oracle.com:/var/tmp

========

06:25:38    InKB   OutKB   InSeg  OutSeg Reset  AttF %ReTX InConn OutCon Drops
TCP         4.28 11464.8   119.6  4180.9  0.00  0.00 0.000   0.00   0.00  0.00
        outDataBytes                    3813019102
        outDataBytes                    3872846230
        outDataBytes                    3932640721
        outDataBytes                    3992499741
06:25:58    InKB   OutKB   InSeg  OutSeg Reset  AttF %ReTX InConn OutCon Drops
TCP         4.24 11492.4   119.9  4154.2  0.00  0.00 0.000   0.05   0.00  0.00
        outDataBytes                    4052253245
        outDataBytes                    4112416693
        outDataBytes                    4172181761
        outDataBytes                    4232014681
06:26:18    InKB   OutKB   InSeg  OutSeg Reset  AttF %ReTX InConn OutCon Drops
TCP         4.23 11492.4   119.8  4157.6  0.00  0.00 0.000   0.00   0.00  0.00
        outDataBytes                    4291824765
        outDataBytes                    56690497 ------>> has wrapped between samples
        outDataBytes                    116504629
        outDataBytes                    176294109
06:26:38    InKB   OutKB   InSeg  OutSeg Reset  AttF %ReTX InConn OutCon Drops
TCP         4.21 11492.4   119.7  4156.7  0.00  0.00 0.000   0.00   0.00  0.00
        outDataBytes                    236151869
        outDataBytes                    295929765
        outDataBytes                    355241781
06:26:58    InKB   OutKB   InSeg  OutSeg Reset  AttF %ReTX InConn OutCon Drops
TCP         4.27 11462.4   119.5  4190.0  0.00  0.00 0.000   0.00   0.00  0.00
        outDataBytes                    414868405
InKB  / OutKB with the change now look sane, of course you can break this by extending the interval
so the datasource wraps multiple times but that's not the target scenario here, (and a much less tractable issue in this codebase).
